### PR TITLE
Debugger/pull candidate/memory range watch/1

### DIFF
--- a/src/include/cbplugin.h
+++ b/src/include/cbplugin.h
@@ -513,6 +513,7 @@ class PLUGIN_EXPORT cbDebuggerPlugin: public cbPlugin
 
         // watches
         virtual cb::shared_ptr<cbWatch> AddWatch(const wxString& symbol) = 0;
+        virtual cb::shared_ptr<cbWatch> AddMemoryRange(uint64_t address, uint64_t size, const wxString &id ) = 0;
         virtual void DeleteWatch(cb::shared_ptr<cbWatch> watch) = 0;
         virtual bool HasWatch(cb::shared_ptr<cbWatch> watch) = 0;
         virtual void ShowWatchProperties(cb::shared_ptr<cbWatch> watch) = 0;

--- a/src/include/sdk_events.h
+++ b/src/include/sdk_events.h
@@ -432,6 +432,8 @@ extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_STARTED;
 #define EVT_DEBUGGER_STARTED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_STARTED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_PAUSED;
 #define EVT_DEBUGGER_PAUSED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_PAUSED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
+extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_CONTINUED;
+#define cbEVT_DEBUGGER_CONTINUED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_CONTINUED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_FINISHED;
 #define EVT_DEBUGGER_FINISHED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_FINISHED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
 

--- a/src/plugins/debuggergdb/cdb_driver.cpp
+++ b/src/plugins/debuggergdb/cdb_driver.cpp
@@ -214,6 +214,11 @@ void CDB_driver::SetVarValue(cb_unused const wxString& var, cb_unused const wxSt
     NOT_IMPLEMENTED();
 }
 
+void CDB_driver::SetMemoryRangeValue(uint64_t addr, const wxString& value)
+{
+    NOT_IMPLEMENTED();
+}
+
 void CDB_driver::MemoryDump()
 {
     NOT_IMPLEMENTED();
@@ -320,6 +325,18 @@ void CDB_driver::UpdateWatchLocalsArgs(cb::shared_ptr<GDBWatch> const &watch, bo
 void CDB_driver::Attach(cb_unused int pid)
 {
     // FIXME (obfuscated#): implement this
+}
+
+void CDB_driver::UpdateMemoryRangeWatches(MemoryRangeWatchesContainer &watches)
+{
+    // FIXME (bluehazzard#): implement this
+    NOT_IMPLEMENTED();
+}
+
+void CDB_driver::UpdateMemoryRangeWatch(const cb::shared_ptr<GDBMemoryRangeWatch> &watch)
+{
+    // FIXME (bluehazzard#): implement this
+    NOT_IMPLEMENTED();
 }
 
 void CDB_driver::Detach()

--- a/src/plugins/debuggergdb/cdb_driver.cpp
+++ b/src/plugins/debuggergdb/cdb_driver.cpp
@@ -409,6 +409,14 @@ void CDB_driver::ParseOutput(const wxString& output)
     if (notifyChange)
         NotifyCursorChanged();
 
+    if(m_ProgramIsStopped)
+    {
+        // Notify debugger plugins for pause of debug session
+        PluginManager *plm = Manager::Get()->GetPluginManager();
+        CodeBlocksEvent evt(cbEVT_DEBUGGER_PAUSED);
+        plm->NotifyPlugins(evt);
+    }
+
     buffer.Clear();
 }
 

--- a/src/plugins/debuggergdb/cdb_driver.h
+++ b/src/plugins/debuggergdb/cdb_driver.h
@@ -35,6 +35,7 @@ class CDB_driver : public DebuggerDriver
         virtual void CPURegisters();
         virtual void SwitchToFrame(size_t number);
         virtual void SetVarValue(const wxString& var, const wxString& value);
+        virtual void SetMemoryRangeValue(uint64_t addr, const wxString& value);
         virtual void MemoryDump();
         virtual void Attach(int pid);
         virtual void Detach();
@@ -56,6 +57,8 @@ class CDB_driver : public DebuggerDriver
         virtual void UpdateWatches(cb::shared_ptr<GDBWatch> localsWatch, cb::shared_ptr<GDBWatch> funcArgsWatch,
                                    WatchesContainer &watches);
         virtual void UpdateWatch(cb::shared_ptr<GDBWatch> const &watch);
+        virtual void UpdateMemoryRangeWatches(MemoryRangeWatchesContainer &watches);
+        virtual void UpdateMemoryRangeWatch(const cb::shared_ptr<GDBMemoryRangeWatch> &watch);
         virtual void UpdateWatchLocalsArgs(cb::shared_ptr<GDBWatch> const &watch, bool locals);
         virtual void ParseOutput(const wxString& output);
         virtual bool IsDebuggingStarted() const;

--- a/src/plugins/debuggergdb/debugger_defs.cpp
+++ b/src/plugins/debuggergdb/debugger_defs.cpp
@@ -21,11 +21,14 @@
 #include "debuggerdriver.h"
 
 #include <wx/arrimpl.cpp>
+#include <cinttypes>
 
 #if !defined(CB_TEST_PROJECT)
 
 const int DEBUGGER_CURSOR_CHANGED = wxNewId();
 const int DEBUGGER_SHOW_FILE_LINE = wxNewId();
+
+const wxString GDBMemoryRangeWatch::emptyString = wxEmptyString;
 
 DebuggerCmd::DebuggerCmd(DebuggerDriver* driver, const wxString& cmd, bool logToNormalLog)
     : m_Cmd(cmd),
@@ -305,6 +308,34 @@ bool GDBWatch::GetForTooltip() const
 {
     return m_forTooltip;
 }
+
+GDBMemoryRangeWatch::GDBMemoryRangeWatch(uint64_t address, uint64_t size, const wxString& name)
+{
+    m_address = address;
+    m_size = size;
+    m_name = name;
+};
+
+bool GDBMemoryRangeWatch::SetValue(const wxString &value)
+{
+    if (m_value != value)
+    {
+        m_value = value;
+        MarkAsChanged(true);
+    }
+    return true;
+}
+
+wxString GDBMemoryRangeWatch::MakeSymbolToAddress() const
+{
+    const int tmpBuffSize = 20;
+    char tmpAddress[tmpBuffSize];
+
+    memset(tmpAddress, 0, tmpBuffSize);
+    snprintf(tmpAddress, tmpBuffSize, "0x%" PRIx64 " ", GetAddress());
+
+    return wxString::FromUTF8(tmpAddress);
+};
 
 bool IsPointerType(wxString type)
 {

--- a/src/plugins/debuggergdb/debugger_defs.h
+++ b/src/plugins/debuggergdb/debugger_defs.h
@@ -256,9 +256,42 @@ class GDBWatch : public cbWatch
         int m_array_count;
         bool m_is_array;
         bool m_forTooltip;
-    };
+};
+
+class GDBMemoryRangeWatch  : public cbWatch
+{
+        public:
+        GDBMemoryRangeWatch(uint64_t address, uint64_t size, const wxString& name);
+
+        virtual ~GDBMemoryRangeWatch()                  {};
+    public:
+        virtual void GetSymbol(wxString &symbol) const  { symbol = m_name; };
+        virtual void GetValue(wxString &value) const    { value = m_value; };
+        virtual bool SetValue(const wxString &value);
+        virtual void GetFullWatchString(wxString &full_watch) const { full_watch = wxEmptyString; };
+        virtual void GetType(wxString &type) const      { type = wxT("Memory range"); };
+        virtual void SetType(const wxString &type)      { };
+
+        virtual wxString const & GetDebugString() const { return emptyString; };
+
+        wxString MakeSymbolToAddress() const override;
+        bool IsPointerType() const override             { return false; };
+
+        uint64_t GetAddress() const                     {return m_address;};
+        uint64_t GetSize()    const                     {return m_size;};
+
+
+    private:
+        uint64_t m_address;
+        uint64_t m_size;
+        wxString m_name;
+        wxString m_value;
+
+        static const wxString emptyString;
+};
 
 typedef std::vector<cb::shared_ptr<GDBWatch> > WatchesContainer;
+typedef std::vector<cb::shared_ptr<GDBMemoryRangeWatch> > MemoryRangeWatchesContainer;
 
 bool IsPointerType(wxString type);
 wxString CleanStringValue(wxString value);

--- a/src/plugins/debuggergdb/debuggerdriver.h
+++ b/src/plugins/debuggergdb/debuggerdriver.h
@@ -105,6 +105,7 @@ class DebuggerDriver
         virtual void CPURegisters() = 0;
         virtual void SwitchToFrame(size_t number) = 0;
         virtual void SetVarValue(const wxString& var, const wxString& value) = 0;
+        virtual void SetMemoryRangeValue(uint64_t addr, const wxString& value) = 0;
         virtual void MemoryDump() = 0;
         virtual void RunningThreads() = 0;
 
@@ -142,6 +143,9 @@ class DebuggerDriver
                                    WatchesContainer &watches) = 0;
         virtual void UpdateWatch(cb::shared_ptr<GDBWatch> const &watch) = 0;
         virtual void UpdateWatchLocalsArgs(cb::shared_ptr<GDBWatch> const &watch, bool locals) = 0;
+
+        virtual void UpdateMemoryRangeWatches(MemoryRangeWatchesContainer &watches) = 0;
+        virtual void UpdateMemoryRangeWatch(const cb::shared_ptr<GDBMemoryRangeWatch> &watch) = 0;
 
         /** Attach to process */
         virtual void Attach(int pid) = 0;

--- a/src/plugins/debuggergdb/debuggergdb.cpp
+++ b/src/plugins/debuggergdb/debuggergdb.cpp
@@ -1135,6 +1135,8 @@ void DebuggerGDB::RunCommand(int cmd)
     if (!m_pProcess)
         return;
 
+    bool debuggerContinued = false;
+
     switch (cmd)
     {
         case CMD_CONTINUE:
@@ -1145,6 +1147,7 @@ void DebuggerGDB::RunCommand(int cmd)
                 Log(_("Continuing..."));
                 m_State.GetDriver()->Continue();
                 m_State.GetDriver()->ResetCurrentFrame();
+                debuggerContinued = true;
             }
             break;
         }
@@ -1156,6 +1159,7 @@ void DebuggerGDB::RunCommand(int cmd)
             {
                 m_State.GetDriver()->Step();
                 m_State.GetDriver()->ResetCurrentFrame();
+                debuggerContinued = true;
             }
             break;
         }
@@ -1173,6 +1177,7 @@ void DebuggerGDB::RunCommand(int cmd)
                 m_State.GetDriver()->StepInstruction();
                 m_State.GetDriver()->ResetCurrentFrame();
                 m_State.GetDriver()->NotifyCursorChanged();
+                debuggerContinued = true;
             }
             break;
         }
@@ -1190,6 +1195,7 @@ void DebuggerGDB::RunCommand(int cmd)
                 m_State.GetDriver()->StepIntoInstruction();
                 m_State.GetDriver()->ResetCurrentFrame();
                 m_State.GetDriver()->NotifyCursorChanged();
+                debuggerContinued = true;
             }
             break;
         }
@@ -1201,6 +1207,7 @@ void DebuggerGDB::RunCommand(int cmd)
             {
                 m_State.GetDriver()->StepIn();
                 m_State.GetDriver()->ResetCurrentFrame();
+                debuggerContinued = true;
             }
             break;
         }
@@ -1212,6 +1219,7 @@ void DebuggerGDB::RunCommand(int cmd)
             {
                 m_State.GetDriver()->StepOut();
                 m_State.GetDriver()->ResetCurrentFrame();
+                debuggerContinued = true;
             }
             break;
         }
@@ -1264,6 +1272,13 @@ void DebuggerGDB::RunCommand(int cmd)
         }
 
         default: break;
+    }
+
+    if(debuggerContinued)
+    {
+        PluginManager *plm = Manager::Get()->GetPluginManager();
+        CodeBlocksEvent evt(cbEVT_DEBUGGER_CONTINUED);
+        plm->NotifyPlugins(evt);
     }
 }
 

--- a/src/plugins/debuggergdb/debuggergdb.h
+++ b/src/plugins/debuggergdb/debuggergdb.h
@@ -89,8 +89,10 @@ class DebuggerGDB : public cbDebuggerPlugin
         int GetExitCode() const { return m_LastExitCode; }
 
         cb::shared_ptr<cbWatch> AddWatch(const wxString& symbol);
+        cb::shared_ptr<cbWatch> AddMemoryRange(uint64_t address, uint64_t size, const wxString &id );
         void DeleteWatch(cb::shared_ptr<cbWatch> watch);
         bool HasWatch(cb::shared_ptr<cbWatch> watch);
+        bool IsMemoryRangeWatch(cb::shared_ptr<cbWatch> watch);
         void ShowWatchProperties(cb::shared_ptr<cbWatch> watch);
         bool SetWatchValue(cb::shared_ptr<cbWatch> watch, const wxString &value);
         void ExpandWatch(cb::shared_ptr<cbWatch> watch);
@@ -208,6 +210,8 @@ class DebuggerGDB : public cbDebuggerPlugin
         bool m_TemporaryBreak;
 
         WatchesContainer m_watches;
+        MemoryRangeWatchesContainer m_memoryRange;
+
         cb::shared_ptr<GDBWatch> m_localsWatch, m_funcArgsWatch;
         wxString m_watchToDereferenceSymbol;
         wxObject *m_watchToDereferenceProperty;

--- a/src/plugins/debuggergdb/gdb_commands.h
+++ b/src/plugins/debuggergdb/gdb_commands.h
@@ -28,6 +28,8 @@
 #include <logmanager.h>
 #include <macrosmanager.h>
 
+#include <cinttypes>
+
 #include "debugger_defs.h"
 #include "debuggergdb.h"
 #include "gdb_driver.h"
@@ -827,6 +829,79 @@ class GdbCmd_Watch : public DebuggerCmd
                 m_watch->SetValue(msg);
                 Manager::Get()->GetLogManager()->LogError(msg);
             }
+        }
+};
+
+
+/**
+  * Command to read a X bytes from a specific address.
+  */
+class GdbCmd_MemoryRangeWatch : public DebuggerCmd
+{
+        cb::shared_ptr<GDBMemoryRangeWatch> m_watch;
+        wxString m_ParseFunc;
+    public:
+        GdbCmd_MemoryRangeWatch(DebuggerDriver* driver, cb::shared_ptr<GDBMemoryRangeWatch> watch) :
+            DebuggerCmd(driver),
+            m_watch(watch)
+        {
+            // wx2.8 does not support uint64_z for wxstring::printf
+            const size_t tmpBuffSize = 20;
+            char tmpAddr[tmpBuffSize];
+            char tmpSize[tmpBuffSize];
+            memset(tmpAddr, 0, tmpBuffSize);
+            memset(tmpSize, 0, tmpBuffSize);
+            snprintf(tmpAddr, tmpBuffSize, "0x%" PRIx64, m_watch->GetAddress());
+            snprintf(tmpSize, tmpBuffSize, "%" PRIu64, m_watch->GetSize());
+
+            m_Cmd  = wxString(wxT("x /")) << wxString::FromUTF8(tmpSize) << wxT("xb ") << wxString::FromUTF8(tmpAddr);
+        }
+
+        void ParseOutput(const wxString& output)
+        {
+            // output is a series of:
+            //
+            // 0x22ffc0:       0xf0    0xff    0x22    0x00    0x4f    0x6d    0x81    0x7c
+            // or
+            // 0x85267a0 <RS485TxTask::taskProc()::rcptBuf>:   0x00   0x00   0x00   0x00   0x00   0x00   0x00   0x00
+
+
+            wxArrayString lines = GetArrayFromString(output, _T('\n'));
+            wxString addr, memory;
+            std::vector<char> data;
+            for (unsigned int i = 0; i < lines.GetCount(); ++i)
+            {
+                if (reExamineMemoryLine.Matches(lines[i]))
+                {
+                    addr = reExamineMemoryLine.GetMatch(lines[i], 1);
+                    memory = reExamineMemoryLine.GetMatch(lines[i], 2);
+                }
+                else
+                {
+                    if (lines[i].First(_T(':')) == -1)
+                    {
+                        continue;
+                    }
+                    addr = lines[i].BeforeFirst(_T(':'));
+                    memory = lines[i].AfterFirst(_T(':'));
+                }
+
+                size_t pos = memory.find(_T('x'));
+                wxString hexbyte;
+                while (pos != wxString::npos)
+                {
+                    hexbyte.clear();
+                    hexbyte << memory[pos + 1];
+                    hexbyte << memory[pos + 2];
+                    unsigned long value;
+                    hexbyte.ToULong(&value,16);
+                    data.push_back(static_cast<char>(value));
+                    pos = memory.find(_T('x'), pos + 1); // skip current 'x'
+                }
+            }
+            wxString watchString;
+            watchString = wxString::From8BitData(data.data(), data.size());
+            m_watch->SetValue(watchString);
         }
 };
 

--- a/src/plugins/debuggergdb/gdb_driver.cpp
+++ b/src/plugins/debuggergdb/gdb_driver.cpp
@@ -1074,7 +1074,16 @@ void GDB_driver::ParseOutput(const wxString& output)
     }
 
     if (m_ProgramIsStopped)
+    {
+        if(m_DCmds.GetCount() == 0)
+        {
+            PluginManager *plm = Manager::Get()->GetPluginManager();
+            CodeBlocksEvent evt(cbEVT_DEBUGGER_PAUSED);
+            plm->NotifyPlugins(evt);
+        }
         RunQueue();
+    }
+
 }
 
 

--- a/src/plugins/debuggergdb/gdb_driver.cpp
+++ b/src/plugins/debuggergdb/gdb_driver.cpp
@@ -524,6 +524,30 @@ void GDB_driver::SetVarValue(const wxString& var, const wxString& value)
     QueueCommand(new DebuggerCmd(this, wxString::Format(_T("set variable %s=%s"), var.c_str(), cleanValue.c_str())));
 }
 
+void GDB_driver::SetMemoryRangeValue(uint64_t addr, const wxString& value)
+{
+    size_t size = value.size();
+    wxCharBuffer data = value.To8BitData();
+    if(size == 0)
+        return;
+
+    wxString dataStr = wxT("{");
+    for (size_t i = 0; i < size; i++)
+    {
+        dataStr << wxString::Format(wxT("0x%x,"), (uint8_t) data[i]);
+    }
+    dataStr.RemoveLast();
+    dataStr << wxT("}");
+    wxString commandStr;
+    #ifdef __WXMSW__
+    commandStr.Printf(wxT("set {char [%ul]} 0x%" PRIx64 "="), size, addr);
+    #else
+    commandStr.Printf(wxT("set {char [%zu]} 0x%" PRIx64 "="), size, addr);
+    #endif // __WXMSW__
+    commandStr << dataStr;
+    QueueCommand(new DebuggerCmd(this, commandStr));
+}
+
 void GDB_driver::MemoryDump()
 {
     QueueCommand(new GdbCmd_ExamineMemory(this));
@@ -658,10 +682,27 @@ void GDB_driver::UpdateWatches(cb::shared_ptr<GDBWatch> localsWatch, cb::shared_
     }
 }
 
+void GDB_driver::UpdateMemoryRangeWatches(MemoryRangeWatchesContainer &watches)
+{
+    for (MemoryRangeWatchesContainer::iterator it = watches.begin(); it != watches.end(); ++it)
+    {
+        MemoryRangeWatchesContainer::reference watch = *it;
+        if (watch->IsAutoUpdateEnabled())
+        {
+            QueueCommand(new GdbCmd_MemoryRangeWatch(this, watch));
+        }
+    }
+}
+
 void GDB_driver::UpdateWatch(const cb::shared_ptr<GDBWatch> &watch)
 {
     QueueCommand(new GdbCmd_FindWatchType(this, watch));
     QueueCommand(new DbgCmd_UpdateWatchesTree(this));
+}
+
+void GDB_driver::UpdateMemoryRangeWatch(const cb::shared_ptr<GDBMemoryRangeWatch> &watch)
+{
+    QueueCommand(new GdbCmd_MemoryRangeWatch(this, watch));
 }
 
 void GDB_driver::UpdateWatchLocalsArgs(cb::shared_ptr<GDBWatch> const &watch, bool locals)

--- a/src/plugins/debuggergdb/gdb_driver.h
+++ b/src/plugins/debuggergdb/gdb_driver.h
@@ -37,6 +37,7 @@ class GDB_driver : public DebuggerDriver
         virtual void CPURegisters();
         virtual void SwitchToFrame(size_t number);
         virtual void SetVarValue(const wxString& var, const wxString& value);
+        virtual void SetMemoryRangeValue(uint64_t addr, const wxString& value);
         virtual void MemoryDump();
         virtual void Attach(int pid);
         virtual void Detach();
@@ -57,7 +58,9 @@ class GDB_driver : public DebuggerDriver
         virtual void EvaluateSymbol(const wxString& symbol, const wxRect& tipRect);
         virtual void UpdateWatches(cb::shared_ptr<GDBWatch> localsWatch, cb::shared_ptr<GDBWatch> funcArgsWatch,
                                    WatchesContainer &watches);
+        virtual void UpdateMemoryRangeWatches(MemoryRangeWatchesContainer &watches);
         virtual void UpdateWatch(const cb::shared_ptr<GDBWatch> &watch);
+        virtual void UpdateMemoryRangeWatch(const cb::shared_ptr<GDBMemoryRangeWatch> &watch);
         virtual void UpdateWatchLocalsArgs(cb::shared_ptr<GDBWatch> const &watch, bool locals);
         virtual void ParseOutput(const wxString& output);
         virtual bool IsDebuggingStarted() const { return m_IsStarted; }

--- a/src/sdk/manager.cpp
+++ b/src/sdk/manager.cpp
@@ -112,6 +112,7 @@ static wxString GetCodeblocksEventName(wxEventType type)
     else if (type==cbEVT_DEBUGGER_STARTED) name = _T("cbEVT_DEBUGGER_STARTED");
     else if (type==cbEVT_DEBUGGER_STARTED) name = _T("cbEVT_DEBUGGER_STARTED");
     else if (type==cbEVT_DEBUGGER_PAUSED) name = _T("cbEVT_DEBUGGER_PAUSED");
+    else if (type==cbEVT_DEBUGGER_CONTINUED) name = _T("cbEVT_DEBUGGER_CONTINUED");
     else if (type==cbEVT_DEBUGGER_FINISHED) name = _T("cbEVT_DEBUGGER_FINISHED");
     else name = _("unknown CodeBlocksEvent");
 

--- a/src/sdk/sdk_events.cpp
+++ b/src/sdk/sdk_events.cpp
@@ -156,6 +156,7 @@ const wxEventType cbEVT_COMPILE_FILE_REQUEST = wxNewEventType();
 // debugger-related events
 const wxEventType cbEVT_DEBUGGER_STARTED = wxNewEventType();
 const wxEventType cbEVT_DEBUGGER_PAUSED = wxNewEventType();
+const wxEventType cbEVT_DEBUGGER_CONTINUED = wxNewEventType();
 const wxEventType cbEVT_DEBUGGER_FINISHED = wxNewEventType();
 
 // logger-related events


### PR DESCRIPTION
This pull request extends the debugger  with memory range watches
http://forums.codeblocks.org/index.php/topic,21457.30.html

in addition it fixes a bug where debugger events are not fired 
cb92b4a  and adds additional debugger events that are needed for a complete debugger session detection  
4c621f1  and 5240fe6 