### PR TITLE
- Valgrind: Fix PCH in wx30-unix (Thanks stahta01)

### DIFF
--- a/src/plugins/contrib/Valgrind/ValgrindListLog.cpp
+++ b/src/plugins/contrib/Valgrind/ValgrindListLog.cpp
@@ -1,4 +1,4 @@
-#include "sdk_precomp.h"
+#include "sdk.h"
 
 #ifndef CB_PRECOMP
     #include <wx/arrstr.h>

--- a/src/plugins/contrib/Valgrind/Valgrind_wx30-unix.cbp
+++ b/src/plugins/contrib/Valgrind/Valgrind_wx30-unix.cbp
@@ -34,6 +34,7 @@
 			<Add option="-DCB_PRECOMP" />
 			<Add option="-DcbDEBUG" />
 			<Add option="-std=c++11" />
+			<Add directory="../../../.objs30/include" />
 			<Add directory="../../../include" />
 			<Add directory="../../../include/tinyxml" />
 			<Add directory="../../../sdk/wxscintilla/include" />

--- a/src/plugins/contrib/Valgrind/valgrind_config.cpp
+++ b/src/plugins/contrib/Valgrind/valgrind_config.cpp
@@ -1,3 +1,10 @@
+#include "sdk.h"
+#ifndef CB_PRECOMP
+    #include <wx/filedlg.h>
+
+    #include <configmanager.h>
+#endif
+
 #include "valgrind_config.h"
 
 //(*InternalHeaders(ValgrindConfigurationPanel)
@@ -9,9 +16,7 @@
 #include <wx/stattext.h>
 #include <wx/textctrl.h>
 //*)
-#include <wx/filedlg.h>
 
-#include <configmanager.h>
 
 //(*IdInit(ValgrindConfigurationPanel)
 const long ValgrindConfigurationPanel::IdExecutablePath = wxNewId();


### PR DESCRIPTION
Add object search folder for PCH.
Change or add sdk.h include.

This change resulted in my build time dropping from 25 seconds to 8 seconds.
Tim S.
