### PR TITLE
Introduce a DebuggerEvent, an ID for cbWatches, and some code cleanup

### DIFF
--- a/src/include/cbplugin.h
+++ b/src/include/cbplugin.h
@@ -394,6 +394,17 @@ struct cbDebuggerFeature
     };
 };
 
+enum DebugWindows : int
+{
+        Backtrace,
+        CPURegisters,
+        Disassembly,
+        ExamineMemory,
+        MemoryRange,
+        Threads,
+        Watches
+};
+
 /** @brief Base class for debugger plugins
   *
   * This plugin type must offer some pre-defined debug facilities, on top
@@ -608,16 +619,6 @@ class PLUGIN_EXPORT cbDebuggerPlugin: public cbPlugin
         virtual bool CompilerFinished(bool compilerFailed, StartType startType)
         { wxUnusedVar(compilerFailed); wxUnusedVar(startType); return false; }
     public:
-        enum DebugWindows
-        {
-            Backtrace,
-            CPURegisters,
-            Disassembly,
-            ExamineMemory,
-            MemoryRange,
-            Threads,
-            Watches
-        };
 
         virtual void RequestUpdate(DebugWindows window) = 0;
 

--- a/src/include/debuggermanager.h
+++ b/src/include/debuggermanager.h
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <vector>
+#include <atomic>
 
 #include <wx/string.h>
 
@@ -49,8 +50,9 @@ class DLLIMPORT cbBreakpoint
 class DLLIMPORT cbWatch
 {
         cbWatch& operator =(cbWatch &);
-        cbWatch(cbWatch &);
+        cbWatch(cbWatch &)  = delete;
 
+        static std::atomic<int64_t> idCounter;
     public:
         cbWatch();
     public:
@@ -67,6 +69,9 @@ class DLLIMPORT cbWatch
         virtual wxString MakeSymbolToAddress() const;
         /// Tells us if the watch is for pointer variable.
         virtual bool IsPointerType() const;
+
+        bool operator==(const cbWatch& lhs) const { return m_id == lhs.m_id;};
+
     protected:
         virtual ~cbWatch();
     public:
@@ -104,9 +109,11 @@ class DLLIMPORT cbWatch
         bool            m_removed;
         bool            m_expanded;
         bool            m_autoUpdate;
+        int64_t         m_id;
 };
 
 cb::shared_ptr<cbWatch> DLLIMPORT cbGetRootWatch(cb::shared_ptr<cbWatch> watch);
+
 
 class DLLIMPORT cbStackFrame
 {

--- a/src/include/manager.h
+++ b/src/include/manager.h
@@ -65,10 +65,10 @@ public:
     static void Shutdown();
 
     bool ProcessEvent(CodeBlocksEvent&       event);
+    bool ProcessEvent(CodeBlocksDebuggerEvent& event);
     bool ProcessEvent(CodeBlocksDockEvent&   event);
     bool ProcessEvent(CodeBlocksLayoutEvent& event);
     bool ProcessEvent(CodeBlocksLogEvent&    event);
-
 
     /** Use Manager::Get() to get a pointer to its instance
      * Manager::Get() is guaranteed to never return an invalid pointer.
@@ -162,6 +162,7 @@ public:
 
     // event sinks
     void RegisterEventSink(wxEventType eventType, IEventFunctorBase<CodeBlocksEvent>*       functor);
+    void RegisterEventSink(wxEventType eventType, IEventFunctorBase<CodeBlocksDebuggerEvent>* functor);
     void RegisterEventSink(wxEventType eventType, IEventFunctorBase<CodeBlocksDockEvent>*   functor);
     void RegisterEventSink(wxEventType eventType, IEventFunctorBase<CodeBlocksLayoutEvent>* functor);
     void RegisterEventSink(wxEventType eventType, IEventFunctorBase<CodeBlocksLogEvent>*    functor);
@@ -187,6 +188,8 @@ private:
     // event sinks
     typedef std::vector< IEventFunctorBase<CodeBlocksEvent>* >       EventSinksArray;
     typedef std::map< wxEventType, EventSinksArray >                 EventSinksMap;
+    typedef std::vector< IEventFunctorBase<CodeBlocksDebuggerEvent>* > DebuggerEventSinksArray;
+    typedef std::map< wxEventType, DebuggerEventSinksArray >         DebuggerEventSinksMap;
     typedef std::vector< IEventFunctorBase<CodeBlocksDockEvent>* >   DockEventSinksArray;
     typedef std::map< wxEventType, DockEventSinksArray >             DockEventSinksMap;
     typedef std::vector< IEventFunctorBase<CodeBlocksLayoutEvent>* > LayoutEventSinksArray;
@@ -195,6 +198,7 @@ private:
     typedef std::map< wxEventType, LogEventSinksArray >              LogEventSinksMap;
 
     EventSinksMap       m_EventSinks;
+    DebuggerEventSinksMap m_DebuggerEventSinks;
     DockEventSinksMap   m_DockEventSinks;
     LayoutEventSinksMap m_LayoutEventSinks;
     LogEventSinksMap    m_LogEventSinks;

--- a/src/include/pluginmanager.h
+++ b/src/include/pluginmanager.h
@@ -160,6 +160,7 @@ class DLLIMPORT PluginManager : public Mgr<PluginManager>, public wxEvtHandler
         void SetupLocaleDomain(const wxString& DomainName);
 
         void NotifyPlugins(CodeBlocksEvent& event);
+        void NotifyPlugins(CodeBlocksDebuggerEvent& event);
         void NotifyPlugins(CodeBlocksDockEvent& event);
         void NotifyPlugins(CodeBlocksLayoutEvent& event);
 

--- a/src/include/sdk_events.h
+++ b/src/include/sdk_events.h
@@ -14,7 +14,10 @@
 class cbProject;
 class EditorBase;
 class cbPlugin;
+class cbDebuggerPlugin;
+enum DebugWindows : int;
 class Logger;
+class cbWatch;
 
 /** A generic Code::Blocks event. */
 class EVTIMPORT CodeBlocksEvent : public wxCommandEvent
@@ -78,6 +81,45 @@ class EVTIMPORT CodeBlocksEvent : public wxCommandEvent
 		DECLARE_DYNAMIC_CLASS(CodeBlocksEvent)
 };
 typedef void (wxEvtHandler::*CodeBlocksEventFunction)(CodeBlocksEvent&);
+
+class EVTIMPORT CodeBlocksDebuggerEvent : public wxCommandEvent
+{
+	public:
+		CodeBlocksDebuggerEvent(wxEventType commandType = wxEVT_NULL, int id = 0, cbProject* project = nullptr, cbDebuggerPlugin* plugin = nullptr)
+			: wxCommandEvent(commandType, id),
+			m_pProject(project),
+			m_pPlugin(plugin)
+            {}
+		CodeBlocksDebuggerEvent(const CodeBlocksDebuggerEvent& event)
+			: wxCommandEvent(event),
+			m_pProject(event.m_pProject),
+			m_pPlugin(event.m_pPlugin)
+			{}
+		wxCommandEvent *Clone() const override { return new CodeBlocksDebuggerEvent(*this); }
+
+		cbProject* GetProject() const             { return m_pProject;    }
+		void       SetProject(cbProject* project) { m_pProject = project; }
+
+		cbDebuggerPlugin* GetPlugin() const           { return m_pPlugin;   }
+		void      SetPlugin(cbDebuggerPlugin* plugin) { m_pPlugin = plugin; }
+
+		DebugWindows GetWindow() const    { return m_Window; }
+		void SetWindow(DebugWindows window)   { m_Window = window; }
+
+		cb::shared_ptr<cbWatch> GetWatch() const            { return m_Watch; }
+		void SetWatch(const cb::shared_ptr<cbWatch>& watch) { m_Watch = watch; }
+
+	protected:
+		cbProject*  m_pProject;
+		cbDebuggerPlugin*   m_pPlugin;
+
+		DebugWindows m_Window;
+		cb::shared_ptr<cbWatch> m_Watch;
+
+	private:
+		DECLARE_DYNAMIC_CLASS(CodeBlocksDebuggerEvent)
+};
+typedef void (wxEvtHandler::*CodeBlocksDebuggerEventFunction)(CodeBlocksDebuggerEvent&);
 
 /** Event used to request from the main app to add a window to the docking system. */
 class EVTIMPORT CodeBlocksDockEvent : public wxEvent
@@ -431,18 +473,18 @@ extern EVTIMPORT const wxEventType cbEVT_COMPILE_FILE_REQUEST;
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_STARTED;
 #define EVT_DEBUGGER_STARTED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_STARTED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_PAUSED;
-#define EVT_DEBUGGER_PAUSED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_PAUSED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
+#define EVT_DEBUGGER_PAUSED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_PAUSED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksDebuggerEventFunction)&fn, (wxObject *) NULL ),
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_CONTINUED;
-#define cbEVT_DEBUGGER_CONTINUED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_CONTINUED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
+#define cbEVT_DEBUGGER_CONTINUED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_CONTINUED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksDebuggerEventFunction)&fn, (wxObject *) NULL ),
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_FINISHED;
-#define EVT_DEBUGGER_FINISHED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_FINISHED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
+#define EVT_DEBUGGER_FINISHED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_FINISHED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksDebuggerEventFunction)&fn, (wxObject *) NULL ),
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_CURSOR_CHANGED;
-#define EVT_DEBUGGER_CURSOR_CHANGED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_CURSOR_CHANGED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
+#define EVT_DEBUGGER_CURSOR_CHANGED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_CURSOR_CHANGED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksDebuggerEventFunction)&fn, (wxObject *) NULL ),
 /// Event sent when the data for a particular debug window is acquired by the debugger plugin and
 /// can be presented to the user. Calling GetInt on the event object can be used to find out the
 /// type of window which has been updated. The value has type cbDebuggerPlugin::DebugWindows.
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_UPDATED;
-#define EVT_DEBUGGER_UPDATED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_UPDATED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksEventFunction)&fn, (wxObject *) NULL ),
+#define EVT_DEBUGGER_UPDATED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_UPDATED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksDebuggerEventFunction)&fn, (wxObject *) NULL ),
 
 // logger-related events
 

--- a/src/include/sdk_events.h
+++ b/src/include/sdk_events.h
@@ -481,8 +481,10 @@ extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_FINISHED;
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_CURSOR_CHANGED;
 #define EVT_DEBUGGER_CURSOR_CHANGED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_CURSOR_CHANGED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksDebuggerEventFunction)&fn, (wxObject *) NULL ),
 /// Event sent when the data for a particular debug window is acquired by the debugger plugin and
-/// can be presented to the user. Calling GetInt on the event object can be used to find out the
-/// type of window which has been updated. The value has type cbDebuggerPlugin::DebugWindows.
+/// can be presented to the user. Calling GetWindow on the event object can be used to find out the
+/// type of window which has been updated.
+/// If the window is DebugWindows::MemoryRange, then the updated watch is returned with GetWatch(). If the
+/// returned shared_ptr is not valid, then multiple watches were updated.
 extern EVTIMPORT const wxEventType cbEVT_DEBUGGER_UPDATED;
 #define EVT_DEBUGGER_UPDATED(fn) DECLARE_EVENT_TABLE_ENTRY( cbEVT_DEBUGGER_UPDATED, -1, -1, (wxObjectEventFunction)(wxEventFunction)(CodeBlocksDebuggerEventFunction)&fn, (wxObject *) NULL ),
 

--- a/src/plugins/debuggergdb/cdb_driver.cpp
+++ b/src/plugins/debuggergdb/cdb_driver.cpp
@@ -303,7 +303,7 @@ void CDB_driver::UpdateWatches(cb_unused cb::shared_ptr<GDBWatch> localsWatch,
     }
 
     if (updateWatches)
-        QueueCommand(new DbgCmd_UpdateWindow(this, cbDebuggerPlugin::DebugWindows::Watches));
+        QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::Watches));
 
     // FIXME (obfuscated#): reimplement this code
 //    // start updating watches tree
@@ -327,7 +327,7 @@ void CDB_driver::UpdateWatches(cb_unused cb::shared_ptr<GDBWatch> localsWatch,
 void CDB_driver::UpdateWatch(const cb::shared_ptr<GDBWatch> &watch)
 {
     QueueCommand(new CdbCmd_Watch(this, watch));
-    QueueCommand(new DbgCmd_UpdateWindow(this, cbDebuggerPlugin::DebugWindows::Watches));
+    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::Watches));
 }
 
 void CDB_driver::UpdateWatchLocalsArgs(cb_unused cb::shared_ptr<GDBWatch> const &watch,

--- a/src/plugins/debuggergdb/debugger_defs.cpp
+++ b/src/plugins/debuggergdb/debugger_defs.cpp
@@ -49,11 +49,21 @@ DbgCmd_UpdateWindow::DbgCmd_UpdateWindow(DebuggerDriver* driver,
 {
 }
 
+DbgCmd_UpdateWindow::DbgCmd_UpdateWindow(DebuggerDriver* driver,
+                                         DebugWindows windowToUpdate,
+                                         const cb::shared_ptr<cbWatch>& watch) :
+    DebuggerCmd(driver),
+    m_windowToUpdate(windowToUpdate),
+    m_watch(watch)
+{
+}
+
 void DbgCmd_UpdateWindow::Action()
 {
-    CodeBlocksEvent event(cbEVT_DEBUGGER_UPDATED);
-    event.SetInt(int(m_windowToUpdate));
+    CodeBlocksDebuggerEvent event(cbEVT_DEBUGGER_UPDATED);
+    event.SetWindow(m_windowToUpdate);
     event.SetPlugin(m_pDriver->GetDebugger());
+    event.SetWatch(m_watch);
     Manager::Get()->ProcessEvent(event);
 }
 

--- a/src/plugins/debuggergdb/debugger_defs.cpp
+++ b/src/plugins/debuggergdb/debugger_defs.cpp
@@ -43,7 +43,7 @@ void DebuggerCmd::ParseOutput(const wxString& output)
 }
 
 DbgCmd_UpdateWindow::DbgCmd_UpdateWindow(DebuggerDriver* driver,
-                                         cbDebuggerPlugin::DebugWindows windowToUpdate) :
+                                         DebugWindows windowToUpdate) :
     DebuggerCmd(driver),
     m_windowToUpdate(windowToUpdate)
 {

--- a/src/plugins/debuggergdb/debugger_defs.h
+++ b/src/plugins/debuggergdb/debugger_defs.h
@@ -118,10 +118,12 @@ class DbgCmd_UpdateWindow : public DebuggerCmd
 {
     public:
         DbgCmd_UpdateWindow(DebuggerDriver* driver, DebugWindows windowToUpdate);
+        DbgCmd_UpdateWindow(DebuggerDriver* driver, DebugWindows windowToUpdate, const cb::shared_ptr<cbWatch>& watch);
         void Action() override;
 
     private:
         DebugWindows m_windowToUpdate;
+        cb::shared_ptr<cbWatch> m_watch;
 };
 
 /** Debugger breakpoint interface.
@@ -231,6 +233,7 @@ class GDBWatch : public cbWatch
 
         wxString MakeSymbolToAddress() const override;
         bool IsPointerType() const override;
+
     public:
         void SetDebugValue(wxString const &value);
         void SetSymbol(const wxString& symbol);

--- a/src/plugins/debuggergdb/debugger_defs.h
+++ b/src/plugins/debuggergdb/debugger_defs.h
@@ -117,11 +117,11 @@ class DebuggerContinueBaseCmd : public DebuggerCmd
 class DbgCmd_UpdateWindow : public DebuggerCmd
 {
     public:
-        DbgCmd_UpdateWindow(DebuggerDriver* driver, cbDebuggerPlugin::DebugWindows windowToUpdate);
+        DbgCmd_UpdateWindow(DebuggerDriver* driver, DebugWindows windowToUpdate);
         void Action() override;
 
     private:
-        cbDebuggerPlugin::DebugWindows m_windowToUpdate;
+        DebugWindows m_windowToUpdate;
 };
 
 /** Debugger breakpoint interface.

--- a/src/plugins/debuggergdb/debuggergdb.cpp
+++ b/src/plugins/debuggergdb/debuggergdb.cpp
@@ -314,7 +314,7 @@ void DebuggerGDB::OnConfigurationChange(cb_unused bool isActive)
         update = true;
 
     if (update)
-        RequestUpdate(cbDebuggerPlugin::Watches);
+        RequestUpdate(DebugWindows::Watches);
 }
 
 wxArrayString DebuggerGDB::ParseSearchDirs(const cbProject &project)

--- a/src/plugins/debuggergdb/debuggergdb.cpp
+++ b/src/plugins/debuggergdb/debuggergdb.cpp
@@ -1347,7 +1347,7 @@ void DebuggerGDB::RunCommand(int cmd)
     if (debuggerContinued)
     {
         PluginManager *plm = Manager::Get()->GetPluginManager();
-        CodeBlocksEvent evt(cbEVT_DEBUGGER_CONTINUED);
+        CodeBlocksDebuggerEvent evt(cbEVT_DEBUGGER_CONTINUED);
         evt.SetPlugin(this);
         plm->NotifyPlugins(evt);
     }
@@ -1749,7 +1749,7 @@ void DebuggerGDB::DoBreak(bool temporary)
     #endif
         // Notify debugger plugins for end of debug session
         PluginManager *plm = Manager::Get()->GetPluginManager();
-        CodeBlocksEvent evt(cbEVT_DEBUGGER_PAUSED);
+        CodeBlocksDebuggerEvent evt(cbEVT_DEBUGGER_PAUSED);
         plm->NotifyPlugins(evt);
     }
 }
@@ -1956,7 +1956,7 @@ void DebuggerGDB::OnGDBTerminated(wxCommandEvent& event)
 
     // Notify debugger plugins for end of debug session
     PluginManager *plm = Manager::Get()->GetPluginManager();
-    CodeBlocksEvent evt(cbEVT_DEBUGGER_FINISHED);
+    CodeBlocksDebuggerEvent evt(cbEVT_DEBUGGER_FINISHED);
     plm->NotifyPlugins(evt);
 
     // switch to the user-defined layout when finished debugging
@@ -2138,7 +2138,7 @@ void DebuggerGDB::OnCursorChanged(wxCommandEvent& WXUNUSED(event))
             // Notify everybody that the debugger cursor has changed.
             // This might be used by some view windows to request the debugger plugin to update some
             // data.
-            CodeBlocksEvent cursorChangeEvent(cbEVT_DEBUGGER_CURSOR_CHANGED);
+            CodeBlocksDebuggerEvent cursorChangeEvent(cbEVT_DEBUGGER_CURSOR_CHANGED);
             cursorChangeEvent.SetPlugin(this);
             Manager::Get()->ProcessEvent(cursorChangeEvent);
         }

--- a/src/plugins/debuggergdb/gdb_driver.cpp
+++ b/src/plugins/debuggergdb/gdb_driver.cpp
@@ -683,13 +683,13 @@ void GDB_driver::UpdateMemoryRangeWatches(MemoryRangeWatchesContainer &watches,
 void GDB_driver::UpdateWatch(const cb::shared_ptr<GDBWatch> &watch)
 {
     QueueCommand(new GdbCmd_FindWatchType(this, watch));
-    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::Watches));
+    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::Watches, watch));
 }
 
 void GDB_driver::UpdateMemoryRangeWatch(const cb::shared_ptr<GDBMemoryRangeWatch> &watch)
 {
     QueueCommand(new GdbCmd_MemoryRangeWatch(this, watch));
-    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::MemoryRange));
+    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::MemoryRange, watch));
 }
 
 void GDB_driver::UpdateWatchLocalsArgs(cb::shared_ptr<GDBWatch> const &watch, bool locals)

--- a/src/plugins/debuggergdb/gdb_driver.cpp
+++ b/src/plugins/debuggergdb/gdb_driver.cpp
@@ -659,7 +659,7 @@ void GDB_driver::UpdateWatches(cb::shared_ptr<GDBWatch> localsWatch,
     if (updateWatches)
     {
         // run this action-only command to update the tree
-        QueueCommand(new DbgCmd_UpdateWindow(this, cbDebuggerPlugin::DebugWindows::Watches));
+        QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::Watches));
     }
 }
 
@@ -677,25 +677,25 @@ void GDB_driver::UpdateMemoryRangeWatches(MemoryRangeWatchesContainer &watches,
     }
 
     if (updateWatches)
-        QueueCommand(new DbgCmd_UpdateWindow(this, cbDebuggerPlugin::DebugWindows::MemoryRange));
+        QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::MemoryRange));
 }
 
 void GDB_driver::UpdateWatch(const cb::shared_ptr<GDBWatch> &watch)
 {
     QueueCommand(new GdbCmd_FindWatchType(this, watch));
-    QueueCommand(new DbgCmd_UpdateWindow(this, cbDebuggerPlugin::DebugWindows::Watches));
+    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::Watches));
 }
 
 void GDB_driver::UpdateMemoryRangeWatch(const cb::shared_ptr<GDBMemoryRangeWatch> &watch)
 {
     QueueCommand(new GdbCmd_MemoryRangeWatch(this, watch));
-    QueueCommand(new DbgCmd_UpdateWindow(this, cbDebuggerPlugin::DebugWindows::MemoryRange));
+    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::MemoryRange));
 }
 
 void GDB_driver::UpdateWatchLocalsArgs(cb::shared_ptr<GDBWatch> const &watch, bool locals)
 {
     QueueCommand(new GdbCmd_LocalsFuncArgs(this, watch, locals));
-    QueueCommand(new DbgCmd_UpdateWindow(this, cbDebuggerPlugin::DebugWindows::Watches));
+    QueueCommand(new DbgCmd_UpdateWindow(this, DebugWindows::Watches));
 }
 
 void GDB_driver::Attach(int pid)

--- a/src/sdk/debuggermanager.cpp
+++ b/src/sdk/debuggermanager.cpp
@@ -42,12 +42,15 @@
 #include "loggers.h"
 #include "manager.h"
 
+std::atomic<int64_t> cbWatch::idCounter(1);
+
 cbWatch::cbWatch() :
     m_changed(true),
     m_removed(false),
     m_expanded(false),
     m_autoUpdate(true)
 {
+    m_id = idCounter.fetch_add(1);
 }
 
 cbWatch::~cbWatch()

--- a/src/sdk/manager.cpp
+++ b/src/sdk/manager.cpp
@@ -262,103 +262,27 @@ void Manager::Shutdown()
 
 bool Manager::ProcessEvent(CodeBlocksEvent& event)
 {
-    if (IsAppShuttingDown())
-        return false;
-
-    EventSinksMap::iterator mit = m_EventSinks.find(event.GetEventType());
-    if (mit != m_EventSinks.end())
-    {
-        for (EventSinksArray::iterator it = mit->second.begin(); it != mit->second.end(); ++it)
-        {
-#ifdef PPRCESS_EVENT_PERFORMANCE_MEASURE
-            wxStopWatch sw;
-#endif // PPRCESS_EVENT_PERFORMANCE_MEASURE
-
-            (*it)->Call(event);
-
-#ifdef PPRCESS_EVENT_PERFORMANCE_MEASURE
-            if(sw.Time() > 10) // only print a handler run longer than 10 ms
-            {
-                // get a mangled C++ name of the function
-                const char *p = (*it)->GetTypeName();
-                int   status;
-                char *realname;
-                realname = abi::__cxa_demangle(p, 0, 0, &status);
-                wxString msg;
-
-                // if the demangled C++ function name success, then realname is not NULL
-                if (realname != 0)
-                {
-                    msg = wxString::FromUTF8(realname);
-                    free(realname);
-                }
-                else
-                    msg = wxString::FromUTF8(p);
-
-                wxEventType type=event.GetEventType();
-                msg << GetCodeblocksEventName(type);
-                Manager::Get()->GetLogManager()->DebugLog(F(_("%s take %ld ms"), msg.wx_str(), sw.Time()));
-            }
-#endif // PPRCESS_EVENT_PERFORMANCE_MEASURE
-        }
-    }
-    return true;
+    return ProcessEvent(event, m_EventSinks);
 }
 
 bool Manager::ProcessEvent(CodeBlocksDebuggerEvent& event)
 {
-    if (IsAppShuttingDown())
-        return false;
-
-    DebuggerEventSinksMap::iterator mit = m_DebuggerEventSinks.find(event.GetEventType());
-    if (mit != m_DebuggerEventSinks.end())
-    {
-        for (DebuggerEventSinksArray::iterator it = mit->second.begin(); it != mit->second.end(); ++it)
-            (*it)->Call(event);
-    }
-    return true;
+    return ProcessEvent(event, m_DebuggerEventSinks);
 }
 
 bool Manager::ProcessEvent(CodeBlocksDockEvent& event)
 {
-    if (IsAppShuttingDown())
-        return false;
-
-    DockEventSinksMap::iterator mit = m_DockEventSinks.find(event.GetEventType());
-    if (mit != m_DockEventSinks.end())
-    {
-        for (DockEventSinksArray::iterator it = mit->second.begin(); it != mit->second.end(); ++it)
-            (*it)->Call(event);
-    }
-    return true;
+    return ProcessEvent(event, m_DockEventSinks);
 }
 
 bool Manager::ProcessEvent(CodeBlocksLayoutEvent& event)
 {
-    if (IsAppShuttingDown())
-        return false;
-
-    LayoutEventSinksMap::iterator mit = m_LayoutEventSinks.find(event.GetEventType());
-    if (mit != m_LayoutEventSinks.end())
-    {
-        for (LayoutEventSinksArray::iterator it = mit->second.begin(); it != mit->second.end(); ++it)
-            (*it)->Call(event);
-    }
-    return true;
+    return ProcessEvent(event, m_LayoutEventSinks);
 }
 
 bool Manager::ProcessEvent(CodeBlocksLogEvent& event)
 {
-    if (IsAppShuttingDown())
-        return false;
-
-    LogEventSinksMap::iterator mit = m_LogEventSinks.find(event.GetEventType());
-    if (mit != m_LogEventSinks.end())
-    {
-        for (LogEventSinksArray::iterator it = mit->second.begin(); it != mit->second.end(); ++it)
-            (*it)->Call(event);
-    }
-    return true;
+    return ProcessEvent(event, m_LogEventSinks);
 }
 
 bool Manager::IsAppShuttingDown()

--- a/src/sdk/pluginmanager.cpp
+++ b/src/sdk/pluginmanager.cpp
@@ -1524,6 +1524,11 @@ void PluginManager::NotifyPlugins(CodeBlocksEvent& event)
     Manager::Get()->ProcessEvent(event);
 }
 
+void PluginManager::NotifyPlugins(CodeBlocksDebuggerEvent& event)
+{
+    Manager::Get()->ProcessEvent(event);
+}
+
 void PluginManager::NotifyPlugins(CodeBlocksDockEvent& event)
 {
     Manager::Get()->ProcessEvent(event);

--- a/src/sdk/sdk_events.cpp
+++ b/src/sdk/sdk_events.cpp
@@ -19,6 +19,7 @@
 
 
 IMPLEMENT_DYNAMIC_CLASS(CodeBlocksEvent, wxEvent)
+IMPLEMENT_DYNAMIC_CLASS(CodeBlocksDebuggerEvent, wxEvent)
 IMPLEMENT_DYNAMIC_CLASS(CodeBlocksDockEvent, wxEvent)
 IMPLEMENT_DYNAMIC_CLASS(CodeBlocksLayoutEvent, wxEvent)
 IMPLEMENT_DYNAMIC_CLASS(CodeBlocksLogEvent, wxEvent)

--- a/src/src/debuggermenu.cpp
+++ b/src/src/debuggermenu.cpp
@@ -155,7 +155,7 @@ template<typename DlgType>
 struct CommonItem : cbDebuggerWindowMenuItem
 {
     typedef DlgType* (DebuggerManager::*GetWindowFunc)();
-    CommonItem(cbDebuggerFeature::Flags enableFeature, cbDebuggerPlugin::DebugWindows requestUpdate, GetWindowFunc func) :
+    CommonItem(cbDebuggerFeature::Flags enableFeature, DebugWindows requestUpdate, GetWindowFunc func) :
         m_enableFeature(enableFeature),
         m_requestUpdate(requestUpdate),
         m_getWindowFunc(func)
@@ -186,13 +186,13 @@ struct CommonItem : cbDebuggerWindowMenuItem
     }
 private:
     cbDebuggerFeature::Flags m_enableFeature;
-    cbDebuggerPlugin::DebugWindows m_requestUpdate;
+    DebugWindows m_requestUpdate;
     GetWindowFunc m_getWindowFunc;
 };
 
 template<typename DlgType>
 CommonItem<DlgType>* MakeItem(cbDebuggerFeature::Flags enableFeature,
-                              cbDebuggerPlugin::DebugWindows requestUpdate,
+                              DebugWindows requestUpdate,
                               DlgType* (DebuggerManager::*func)())
 {
     return new CommonItem<DlgType>(enableFeature, requestUpdate, func);
@@ -227,7 +227,7 @@ void DebuggerMenuHandler::RegisterDefaultWindowItems()
     struct Watches : CommonItem<cbWatchesDlg>
     {
         Watches() :
-            CommonItem<cbWatchesDlg>(cbDebuggerFeature::Watches, cbDebuggerPlugin::Watches, &DebuggerManager::GetWatchesDialog)
+            CommonItem<cbWatchesDlg>(cbDebuggerFeature::Watches, DebugWindows::Watches, &DebuggerManager::GetWatchesDialog)
         {
         }
         bool IsEnabled() override
@@ -239,20 +239,20 @@ void DebuggerMenuHandler::RegisterDefaultWindowItems()
     RegisterWindowMenu(_("Breakpoints"), _("Edit breakpoints"), new Breakpoints);
     RegisterWindowMenu(_("Watches"), _("Watch variables"), new Watches);
     RegisterWindowMenu(_("Call stack"), _("Displays the current call stack"),
-                       MakeItem(cbDebuggerFeature::Callstack, cbDebuggerPlugin::Backtrace,
+                       MakeItem(cbDebuggerFeature::Callstack, DebugWindows::Backtrace,
                                 &DebuggerManager::GetBacktraceDialog));
     RegisterWindowMenu(_("CPU Registers"), _("Display the CPU registers"),
-                       MakeItem(cbDebuggerFeature::CPURegisters, cbDebuggerPlugin::CPURegisters,
+                       MakeItem(cbDebuggerFeature::CPURegisters, DebugWindows::CPURegisters,
                                 &DebuggerManager::GetCPURegistersDialog));
     RegisterWindowMenu(_("Disassembly"), _("Disassembles the current stack frame"),
-                       MakeItem(cbDebuggerFeature::Disassembly, cbDebuggerPlugin::Disassembly,
+                       MakeItem(cbDebuggerFeature::Disassembly, DebugWindows::Disassembly,
                                 &DebuggerManager::GetDisassemblyDialog));
     RegisterWindowMenu(_("Memory dump"), _("Displays the contents of a memory location"),
-                       MakeItem(cbDebuggerFeature::ExamineMemory, cbDebuggerPlugin::ExamineMemory,
+                       MakeItem(cbDebuggerFeature::ExamineMemory, DebugWindows::ExamineMemory,
                                 &DebuggerManager::GetExamineMemoryDialog));
     RegisterWindowMenu(_("Running threads"),
                        _("Displays the currently running threads and allows switching between them"),
-                       MakeItem(cbDebuggerFeature::Threads, cbDebuggerPlugin::Threads,
+                       MakeItem(cbDebuggerFeature::Threads, DebugWindows::Threads,
                                 &DebuggerManager::GetThreadsDialog));
 }
 

--- a/src/src/disassemblydlg.cpp
+++ b/src/src/disassemblydlg.cpp
@@ -261,7 +261,7 @@ void DisassemblyDlg::OnRefresh(cb_unused wxCommandEvent& event)
 {
     cbDebuggerPlugin *plugin = Manager::Get()->GetDebuggerManager()->GetActiveDebugger();
     cbAssert(plugin);
-    plugin->RequestUpdate(cbDebuggerPlugin::Disassembly);
+    plugin->RequestUpdate(DebugWindows::Disassembly);
 }
 
 void DisassemblyDlg::OnMixedModeCB(cb_unused wxCommandEvent &event)
@@ -273,7 +273,7 @@ void DisassemblyDlg::OnMixedModeCB(cb_unused wxCommandEvent &event)
 
     cbDebuggerPlugin *plugin = manager.GetActiveDebugger();
     cbAssert(plugin);
-    plugin->RequestUpdate(cbDebuggerPlugin::Disassembly);
+    plugin->RequestUpdate(DebugWindows::Disassembly);
 }
 
 void DisassemblyDlg::EnableWindow(bool enable)

--- a/src/src/examinememorydlg.cpp
+++ b/src/src/examinememorydlg.cpp
@@ -142,7 +142,7 @@ void ExamineMemoryDlg::OnGo(cb_unused wxCommandEvent& event)
     c->Write(wxT("/common/examine_memory/size_to_show"), GetBytes());
 
     if (plugin)
-        plugin->RequestUpdate(cbDebuggerPlugin::ExamineMemory);
+        plugin->RequestUpdate(DebugWindows::ExamineMemory);
 }
 
 void ExamineMemoryDlg::EnableWindow(bool enable)
@@ -156,6 +156,6 @@ void ExamineMemoryDlg::SetBaseAddress(const wxString &addr)
 
     cbDebuggerPlugin *plugin = Manager::Get()->GetDebuggerManager()->GetActiveDebugger();
     if (plugin)
-        plugin->RequestUpdate(cbDebuggerPlugin::ExamineMemory);
+        plugin->RequestUpdate(DebugWindows::ExamineMemory);
 
 }

--- a/src/src/watchesdlg.cpp
+++ b/src/src/watchesdlg.cpp
@@ -539,7 +539,7 @@ inline void SetValue(WatchesProperty *prop)
 
 void WatchesDlg::OnDebuggerUpdated(CodeBlocksEvent &event)
 {
-    if (cbDebuggerPlugin::DebugWindows(event.GetInt()) != cbDebuggerPlugin::DebugWindows::Watches)
+    if (DebugWindows(event.GetInt()) != DebugWindows::Watches)
         return;
 
     for (WatchItems::iterator it = m_watches.begin(); it != m_watches.end(); ++it)

--- a/src/src/watchesdlg.cpp
+++ b/src/src/watchesdlg.cpp
@@ -429,7 +429,7 @@ WatchesDlg::WatchesDlg() :
     ColourManager *colours = manager->GetColourManager();
     colours->RegisterColour(_("Debugger"), _("Watches changed value"), wxT("dbg_watches_changed"), *wxRED);
 
-    typedef cbEventFunctor<WatchesDlg, CodeBlocksEvent> Functor;
+    typedef cbEventFunctor<WatchesDlg, CodeBlocksDebuggerEvent> Functor;
     manager->RegisterEventSink(cbEVT_DEBUGGER_UPDATED,
                                new Functor(this, &WatchesDlg::OnDebuggerUpdated));
 }
@@ -537,9 +537,9 @@ inline void SetValue(WatchesProperty *prop)
     }
 }
 
-void WatchesDlg::OnDebuggerUpdated(CodeBlocksEvent &event)
+void WatchesDlg::OnDebuggerUpdated(CodeBlocksDebuggerEvent &event)
 {
-    if (DebugWindows(event.GetInt()) != DebugWindows::Watches)
+    if (event.GetWindow() != DebugWindows::Watches)
         return;
 
     for (WatchItems::iterator it = m_watches.begin(); it != m_watches.end(); ++it)

--- a/src/src/watchesdlg.h
+++ b/src/src/watchesdlg.h
@@ -52,7 +52,7 @@ class WatchesDlg : public wxPanel, public cbWatchesDlg
         void OnMenuAutoUpdate(wxCommandEvent &event);
         void OnMenuUpdate(wxCommandEvent &event);
 
-        void OnDebuggerUpdated(CodeBlocksEvent &event);
+        void OnDebuggerUpdated(CodeBlocksDebuggerEvent &event);
 
         DECLARE_EVENT_TABLE()
 


### PR DESCRIPTION
This branch will add dedicated Debugger events for cbEVT_DEBUGGER_CURSOR_CHANGED, cbEVT_DEBUGGER_UPDATED ecc.
It also adds an ID to the cbWatch component, that allows comparison of watches. This allows to identify what watch changed during an cbEVT_DEBUGGER_UPDATED  event. It makes also the interface nicer, by using the DebuggerWindows enum directly and not going over an int
Discussion: https://forums.codeblocks.org/index.php/topic,24385.0.html