### PR TITLE
Ticket 1128 - When loading a workspace if project(s) fail to load show up to 10 in the cbMessageBox

### DIFF
--- a/src/sdk/workspaceloader.cpp
+++ b/src/sdk/workspaceloader.cpp
@@ -96,7 +96,8 @@ bool WorkspaceLoader::Open(const wxString& filename, wxString& Title)
         return false;
     }
 
-    int failedProjects = 0;
+    int failedProjectCount = 0;
+    wxString failedProjectNames =  wxString();
     // first loop to load projects
     while (proj)
     {
@@ -118,7 +119,13 @@ bool WorkspaceLoader::Open(const wxString& filename, wxString& Title)
                 GetpMsg()->LogError(wxString::Format(_("Unable to open \"%s\" during opening workspace \"%s\" "),
                                                        projectFilename.c_str(),
                                                        filename.c_str()));
-                failedProjects++;
+                // Only display a max of 10 failed projects!!!
+                if (failedProjectCount < 10)
+                {
+                    failedProjectNames.Append("\n");
+                    failedProjectNames.Append(projectFilename);
+                }
+                failedProjectCount++;
             }
         }
         proj = proj->NextSiblingElement("Project");
@@ -160,10 +167,10 @@ bool WorkspaceLoader::Open(const wxString& filename, wxString& Title)
         proj = proj->NextSiblingElement("Project");
     }
 
-    if (failedProjects > 0)
+    if (failedProjectCount > 0)
     {
-        cbMessageBox(wxString::Format(_("%d projects could not be loaded.\nPlease see the Log window for details"), failedProjects),
-                     _("Opening WorkSpace"), wxICON_WARNING);
+        wxString sMessage = wxString::Format(_("%d projects could not be loaded.\nPlease see the Log window for details.\nThe failed projects are: %s"), failedProjectCount, failedProjectNames);
+        cbMessageBox(sMessage, "Opening WorkSpace", wxICON_WARNING);
     }
 
     return true;


### PR DESCRIPTION
Ticket 1128 details:
If you are running C::B in batch mode the dialog that pops up if a project in the workspace has failed to load does not show which project failed and refers you to the log, which when using the batch mode is not very helpful IMHO.
It would be allot nicer for the end user to show which projects failed to load in the pop up (limited to say the first 10). This will allow the end user to see the projects that failed and not have to look at the log in the vast majority of cases.